### PR TITLE
Added docker configuration for deploying CDK stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 
 # Install global dependencies and clean up in one layer
 RUN npm install -g aws-cdk && \
-    apk add --no-cache bash && \
+    apk add --no-cache bash curl && \
     rm -rf /tmp/* /var/cache/apk/*
 
 # Copy built application from builder stage
@@ -37,6 +37,10 @@ RUN addgroup -S cdkuser && \
 
 # Switch to the non-root user
 USER cdkuser
+
+# Add HEALTHCHECK instruction
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD curl -f http://localhost:3000/ || exit 1
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ and put the email and password in safe somewhere and forget it. Create a new use
 ### Week 2: Container Security and CI/CD Pipeline Integration
 
 #### Day 1-2: Docker Fundamentals and Security
-- [ ] Set up Docker environment
-    - [ ] Install Docker Desktop
-    - [ ] Understand Docker architecture
-- [ ] Study Docker security concepts
-    - [ ] Read Docker security documentation
-    - [ ] Understand container isolation and resource constraints
-- [ ] Create a secure Dockerfile
-    - [ ] Use official base images
-    - [ ] Implement multi-stage builds
-    - [ ] Run containers as non-root user
-- [ ] Implement Docker best practices
-    - [ ] Use .dockerignore files
-    - [ ] Minimize the number of layers
+- ✅ Set up Docker environment
+    - ✅ Install Docker Desktop
+    - ✅ Understand Docker architecture
+- ✅ Study Docker security concepts
+    - ✅ Read Docker security documentation
+    - ✅ Understand container isolation and resource constraints
+- ✅ Create a secure Dockerfile
+    - ✅ Use official base images
+    - ✅ Implement multi-stage builds
+    - ✅ Run containers as non-root user
+- ✅ Implement Docker best practices
+    - ✅ Use .dockerignore files
+    - ✅ Minimize the number of layers
     - [ ] Implement health checks
 
 #### Day 3-4: Container Vulnerability Scanning
@@ -141,6 +141,28 @@ and put the email and password in safe somewhere and forget it. Create a new use
 - Knowledge of container vulnerability scanning using Trivy
 - Implementation of a CI/CD pipeline for secure container deployments
 - Exposure to advanced container security features and monitoring strategies
+- In addition to Trivy, we can also try docker scout. It comes by default and *might* be useful: `docker scout quickview`
+- We can also try docker scout for recommendations - ` docker scout recommendations local://my-cdk-app:latest`
+- To build the dockerfile, run `docker build -t my-cdk-app:latest .`
+- To run the dockerfile -
+  ``` 
+  docker run -it --rm \
+  -v ~/.aws:/home/cdkuser/.aws \
+  -v $(pwd):/app \
+  my-cdk-app:latest
+  ```
+- To run any specific cdk command - 
+  ```
+  docker run -it --rm \
+  -v ~/.aws:/home/cdkuser/.aws \
+  -v $(pwd):/app \
+  my-cdk-app:latest cdk synth --all
+  ```
+- You can verify the number of layers and image size with:
+  ```
+  docker history my-cdk-app:latest
+  docker images my-cdk-app:latest
+  ```
 
 #### Resources Week 2
 - [Docker Security Documentation](https://docs.docker.com/engine/security/)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Print the Node.js version
+echo "Node.js version: $(node --version)"
+echo "NPM version: $(npm --version)"
+
+# Print the current working directory
+echo "Current working directory: $(pwd)"
+
+# List the contents of the current directory
+echo "Contents of the current directory:"
+ls -la
+
+# Print the CDK version
+echo "CDK version: $(cdk --version)"
+
+# If a command is passed to the container, execute it
+if [ "$1" ]; then
+    exec "$@"
+else
+    # Otherwise, start an interactive bash session
+    exec /bin/bash
+fi

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "outDir": "lib",
+    "outDir": "./dist",
     "rootDir": "src",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This is completely overkill and only for the sake of the demo. You don't need to build the deployment in a docker build and then use a separate docker image for deploy. This is not what docker should be used for, only what it can be used for. This was the only project I had at hand, else ideally, I would have used a simple express application, which would have let me incorporate a health check as well