### PR TITLE
Adding a custom IAM policy for the EC2 instance with minimum permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,10 @@ and put the email and password in safe somewhere and forget it. Create a new use
     - ✅ Analyze its findings and understand resource exposure
 
 #### Day 3-4: Implementing Least Privilege Access
-- [ ] Review current IAM policies in your AWS account
-- [ ] Use IAM Access Analyzer to identify overly permissive policies
-- [ ] Create custom IAM policies following least privilege principle
-    - [ ] For EC2 instances
-    - [ ] For Lambda functions
-    - [ ] For ECS tasks
-- [ ] Implement AWS Organizations Service Control Policies (SCPs)
-- [ ] Set up AWS Config to monitor for policy changes
+-  ✅ Review current IAM policies in your AWS account
+-  ✅ Use IAM Access Analyzer to identify overly permissive policies
+-  ✅ Create custom IAM policies following least privilege principle
+    -  ✅ For EC2 instances
 
 #### Day 5-7: Compliance as Code
 - [ ] Study relevant compliance frameworks (e.g., HIPAA, PCI-DSS, GDPR)

--- a/src/apps/InfrastructureStackApp.ts
+++ b/src/apps/InfrastructureStackApp.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { StorageStack } from '../stacks/StorageStack';
 import { ComputeStack } from '../stacks/ComputeStack';
 import { NetworkStack } from '../stacks/NetworkStack';
+import { IamStack } from "../stacks/IamStack";
 
 const app = new cdk.App();
 
@@ -14,11 +15,14 @@ if (!env.account || !env.region) {
     throw new Error('Please specify both CDK_DEFAULT_ACCOUNT and CDK_DEFAULT_REGION (or AWS_ACCOUNT_ID and AWS_DEFAULT_REGION)');
 }
 
+const iamStack = new IamStack(app, 'IamStack', { env });
+
 const networkStack = new NetworkStack(app, 'NetworkStack', { env });
 new StorageStack(app, 'StorageStack', { env });
 new ComputeStack(app, 'ComputeStack', {
     env,
-    vpc: networkStack.vpc
+    vpc: networkStack.vpc,
+    ec2Role: iamStack.ec2Role
 });
 
 app.synth();

--- a/src/constructs/compute/SecureEC2Instance.ts
+++ b/src/constructs/compute/SecureEC2Instance.ts
@@ -1,16 +1,23 @@
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
+import {IRole} from "aws-cdk-lib/aws-iam";
+
+interface SecureEC2InstanceProps {
+    vpc: ec2.IVpc;
+    role?: IRole;
+}
 
 export class SecureEC2Instance extends Construct {
     public readonly instance: ec2.Instance;
 
-    constructor(scope: Construct, id: string, vpc: ec2.IVpc) {
+    constructor(scope: Construct, id: string, props: SecureEC2InstanceProps) {
         super(scope, id);
 
         this.instance = new ec2.Instance(this, 'SecureInstance', {
-            vpc,
+            vpc: props.vpc,
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
             machineImage: new ec2.AmazonLinuxImage(),
+            role: props.role, // Use the provided role or let CDK create a default one
         });
     }
 }

--- a/src/stacks/ComputeStack.ts
+++ b/src/stacks/ComputeStack.ts
@@ -2,14 +2,20 @@ import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 import {SecureEC2Instance} from "../constructs/compute/SecureEC2Instance";
+import {IRole} from "aws-cdk-lib/aws-iam";
 
 interface ComputeStackProps extends cdk.StackProps {
     vpc: ec2.IVpc;
+    ec2Role?: IRole;  // Add this line
 }
 
 export class ComputeStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props: ComputeStackProps) {
         super(scope, id, props);
-        new SecureEC2Instance(this, 'SecureEC2Instance', props.vpc);
+
+        new SecureEC2Instance(this, 'SecureEC2Instance', {
+            vpc: props.vpc,
+            role: props.ec2Role
+        });
     }
 }

--- a/src/stacks/IamStack.ts
+++ b/src/stacks/IamStack.ts
@@ -1,0 +1,35 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+export class IamStack extends cdk.Stack {
+    public readonly ec2Role: iam.Role;
+
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Create EC2 role with the least privilege
+        this.ec2Role = new iam.Role(this, 'EC2LeastPrivilegeRole', {
+            assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+            description: 'Least privilege role for EC2 instances',
+        });
+
+        // Add minimal required permissions
+        this.ec2Role.addToPolicy(new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+                'ec2:DescribeTags',
+                'ec2:DescribeInstances',
+                'cloudwatch:PutMetricData'
+            ],
+            resources: ['*'],
+        }));
+
+        // Export the role ARN
+        new cdk.CfnOutput(this, 'EC2RoleArn', {
+            value: this.ec2Role.roleArn,
+            description: 'ARN of the EC2 least privilege role',
+            exportName: 'EC2LeastPrivilegeRoleArn',
+        });
+    }
+}


### PR DESCRIPTION
## What does this PR do?
- Creates a new IamStack to manage IAM resources
- Implements least-privilege IAM role for EC2 instances with minimal required permissions:
  - ec2:DescribeTags
  - ec2:DescribeInstances
  - cloudwatch:PutMetricData
- Updates SecureEC2Instance construct to accept custom IAM roles
- Modifies ComputeStack to use the new least-privilege role

## Why do we need this?
Following the principle of least privilege, we want to ensure EC2 instances only have the permissions they absolutely need. This change replaces the default EC2 role with a custom role that has minimal permissions, improving our security posture.

## Testing performed
- Synthesized CDK app successfully
- Deployed changes to AWS environment
- Verified EC2 instance can still perform required operations with restricted permissions

## Screenshots/Output
[If you have any relevant AWS Console screenshots or CLI output, add them here]

## Related Issues
Part of Week 3 implementation of least privilege access

## Security Considerations
- Follows AWS security best practices for IAM
- Implements principle of least privilege
- Role permissions can be easily audited and modified as needs change